### PR TITLE
Add fine-tuning demo UI and player components

### DIFF
--- a/dnd-frontend/src/App.tsx
+++ b/dnd-frontend/src/App.tsx
@@ -13,7 +13,7 @@ import { CharacterLibrary } from "./pages/CharacterLibrary";
 import { CharacterCreate } from "./pages/CharacterCreate";
 import { CharacterEdit } from "./pages/CharacterEdit";
 import { CharacterView } from "./pages/CharacterView";
-// import { FineTuningDemo } from "./pages/FineTuningDemo";
+import { FineTuningDemo } from "./pages/FineTuningDemo";
 import "./App.css";
 import { Navbar } from "./components/ui/navbar";
 
@@ -46,7 +46,7 @@ function App() {
               path="/characters/view/:characterId"
               element={<CharacterView />}
             />
-            {/*  <Route path="/fine-tune" element={<FineTuningDemo />} /> */}
+            <Route path="/fine-tune" element={<FineTuningDemo />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </div>

--- a/dnd-frontend/src/components/aicomponent/AIPersonalitySelector.tsx
+++ b/dnd-frontend/src/components/aicomponent/AIPersonalitySelector.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
+
+export interface PersonalityOption {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface AIPersonalitySelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+  personalities?: PersonalityOption[];
+  disabled?: boolean;
+}
+
+const DEFAULT_PERSONALITIES: PersonalityOption[] = [
+  {
+    id: "classic",
+    name: "Classic Fantasy DM",
+    description: "Traditional high fantasy narration",
+  },
+  {
+    id: "tolkien",
+    name: "Tolkien DM",
+    description: "Epic prose inspired by Middle-earth",
+  },
+  {
+    id: "grimdark",
+    name: "Grimdark",
+    description: "Gritty and perilous adventures",
+  },
+];
+
+export function AIPersonalitySelector({
+  value,
+  onChange,
+  personalities = DEFAULT_PERSONALITIES,
+  disabled,
+}: AIPersonalitySelectorProps) {
+  useEffect(() => {
+    if (!value && personalities.length) {
+      onChange(personalities[0].id);
+    }
+  }, [value, personalities, onChange]);
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-muted-foreground mb-1">
+        AI Personality
+      </label>
+      <Select value={value} onValueChange={onChange} disabled={disabled}>
+        <SelectTrigger className="bg-card border border-border text-primary">
+          <SelectValue placeholder="Select personality" />
+        </SelectTrigger>
+        <SelectContent>
+          {personalities.map((p) => (
+            <SelectItem key={p.id} value={p.id}>
+              {p.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {value && (
+        <p className="text-xs text-muted-foreground">
+          {personalities.find((p) => p.id === value)?.description}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/dnd-frontend/src/components/aicomponent/PromptEditor.tsx
+++ b/dnd-frontend/src/components/aicomponent/PromptEditor.tsx
@@ -1,0 +1,24 @@
+import { Textarea } from "../ui/textarea";
+
+interface PromptEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export function PromptEditor({ value, onChange, disabled }: PromptEditorProps) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-muted-foreground mb-1">
+        Custom Prompt
+      </label>
+      <Textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Describe your campaign tone, important NPCs, etc..."
+        className="min-h-[120px] bg-card border border-border text-primary"
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/dnd-frontend/src/components/component-list.md
+++ b/dnd-frontend/src/components/component-list.md
@@ -7,35 +7,35 @@
 ## 🔧 Core Game Components
 
 ### Socket & API
-- [ ] **useSocket** - Hook for WebSocket connection management
-- [ ] **api.ts** - API service functions (createRoom, joinRoom, etc.)
+- [x] **useSocket** - Hook for WebSocket connection management
+- [x] **api.ts** - API service functions (createRoom, joinRoom, etc.)
 
-### Character Management  
-- [ ] **CharacterPanel** - Displays character info in sidebar during game
-- [ ] **AIModelSelector** - Dropdown for selecting AI model (GPT-4, Claude, etc.)
+### Character Management
+- [x] **CharacterPanel** - Displays character info in sidebar during game
+- [x] **AIModelSelector** - Dropdown for selecting AI model (GPT-4, Claude, etc.)
 
 ### Game Communication
-- [ ] **ChatMessage** - Individual message component for game chat
-- [ ] **DiceRoller** - Dice rolling interface with common D&D dice
-- [ ] **GameMap** - Battle map/grid component for tactical combat
+- [x] **ChatMessage** - Individual message component for game chat
+- [x] **DiceRoller** - Dice rolling interface with common D&D dice
+- [x] **GameMap** - Battle map/grid component for tactical combat
 
 ## 🎮 Game Flow Components
 
 ### Room Management
-- [ ] **PlayerList** - Display of players in lobby/game
+- [x] **PlayerList** - Display of players in lobby/game
 - [ ] **RoomSettings** - Game configuration panel
 - [ ] **JoinRoomForm** - Form for joining existing rooms
 
 ### Gameplay Features
-- [ ] **CombatTracker** - Initiative order and turn management
+- [x] **CombatTracker** - Initiative order and turn management
 - [ ] **SpellList** - Searchable spell reference
 - [ ] **InventoryPanel** - Character equipment management
 - [ ] **SkillCheck** - Interface for ability checks and saves
 
 ## 🤖 AI & Customization
-- [ ] **FineTuningDemo** - AI DM customization interface
-- [ ] **PromptEditor** - Text editor for AI prompts
-- [ ] **AIPersonalitySelector** - Pre-built DM personality options
+- [x] **FineTuningDemo** - AI DM customization interface
+- [x] **PromptEditor** - Text editor for AI prompts
+- [x] **AIPersonalitySelector** - Pre-built DM personality options
 
 ## 🎲 D&D Reference Components
 - [ ] **ConditionsReference** - D&D conditions lookup

--- a/dnd-frontend/src/components/game/CombatTracker.tsx
+++ b/dnd-frontend/src/components/game/CombatTracker.tsx
@@ -1,0 +1,46 @@
+import { Badge } from "../ui/badge";
+
+export interface InitiativeEntry {
+  id: string;
+  name: string;
+  initiative: number;
+}
+
+export interface TurnInfo {
+  currentPlayer: string;
+  initiative: InitiativeEntry[];
+}
+
+interface CombatTrackerProps {
+  turn: TurnInfo | undefined;
+}
+
+export function CombatTracker({ turn }: CombatTrackerProps) {
+  if (!turn) {
+    return (
+      <div className="text-center text-sm text-muted-foreground">
+        Waiting for initiative...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {turn.initiative.map((p) => (
+        <div
+          key={p.id}
+          className={`flex items-center justify-between p-2 rounded ${
+            p.id === turn.currentPlayer
+              ? "bg-red-500/20 border border-red-500/50"
+              : "bg-white/5"
+          }`}
+        >
+          <span className="text-white text-sm font-medium">{p.name}</span>
+          <Badge variant="outline" className="text-xs">
+            {p.initiative}
+          </Badge>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dnd-frontend/src/components/game/PlayerList.tsx
+++ b/dnd-frontend/src/components/game/PlayerList.tsx
@@ -1,0 +1,67 @@
+import { Badge } from "../ui/badge";
+
+export interface Player {
+  id: string;
+  name: string;
+  character?: {
+    name: string;
+    class: string;
+    level: number;
+    ready: boolean;
+  };
+  isHost?: boolean;
+}
+
+interface PlayerListProps {
+  players: Player[];
+}
+
+export function PlayerList({ players }: PlayerListProps) {
+  if (!players.length) {
+    return (
+      <div className="text-center text-gray-400 py-8">
+        No players yet
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {players.map((player) => (
+        <div
+          key={player.id}
+          className="flex items-center justify-between p-3 rounded-lg bg-white/5"
+        >
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-white">{player.name}</span>
+              {player.isHost && (
+                <Badge variant="outline" className="text-xs">
+                  Host
+                </Badge>
+              )}
+            </div>
+            {player.character && (
+              <div className="text-sm text-gray-400">
+                {player.character.name} • Level {player.character.level}{" "}
+                {player.character.class}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {player.character?.ready ? (
+              <Badge className="bg-green-900/30 text-green-300">Ready</Badge>
+            ) : (
+              <Badge
+                variant="secondary"
+                className="bg-yellow-900/30 text-yellow-300"
+              >
+                Setup
+              </Badge>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dnd-frontend/src/components/ui/navbar.tsx
+++ b/dnd-frontend/src/components/ui/navbar.tsx
@@ -1,15 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import {
-  User,
-  Settings,
-  Home,
-  Users,
-  BookOpen,
-  ChevronDown,
-  Moon,
-  Sun,
-} from "lucide-react";
+import { User, Settings, ChevronDown, Moon, Sun } from "lucide-react";
 
 export function Navbar() {
   const [dropdownOpen, setDropdownOpen] = useState(false);

--- a/dnd-frontend/src/hooks/useSocket.ts
+++ b/dnd-frontend/src/hooks/useSocket.ts
@@ -67,7 +67,7 @@ export function useSocket(options: SocketOptions = {}) {
     }
   };
 
-  const emit = (event: string, data?: any) => {
+  const emit = (event: string, data?: unknown) => {
     if (socketRef.current && connected) {
       socketRef.current.emit(event, data);
     } else {

--- a/dnd-frontend/src/pages/CharacterEdit.tsx
+++ b/dnd-frontend/src/pages/CharacterEdit.tsx
@@ -136,12 +136,12 @@ export function CharacterEdit() {
 
       try {
         // TODO: Replace with actual API call
-        const characters = JSON.parse(
+        const characters: Record<string, unknown>[] = JSON.parse(
           localStorage.getItem("dnd-characters") || "[]"
         );
         const foundCharacter = characters.find(
-          (c: any) => c.id === characterId
-        );
+          (c) => (c as { id: string }).id === characterId
+        ) as Character | undefined;
 
         if (!foundCharacter) {
           alert("Character not found");
@@ -215,11 +215,11 @@ export function CharacterEdit() {
     setSaving(true);
     try {
       // TODO: Replace with actual API call
-      const characters = JSON.parse(
+      const characters: Record<string, unknown>[] = JSON.parse(
         localStorage.getItem("dnd-characters") || "[]"
       );
-      const updatedCharacters = characters.map((c: any) =>
-        c.id === characterId
+      const updatedCharacters = characters.map((c) =>
+        (c as { id: string }).id === characterId
           ? { ...character, updatedAt: new Date().toISOString() }
           : c
       );
@@ -246,11 +246,11 @@ export function CharacterEdit() {
 
     try {
       // TODO: Replace with actual API call
-      const characters = JSON.parse(
+      const characters: Record<string, unknown>[] = JSON.parse(
         localStorage.getItem("dnd-characters") || "[]"
       );
       const filteredCharacters = characters.filter(
-        (c: any) => c.id !== characterId
+        (c) => (c as { id: string }).id !== characterId
       );
       localStorage.setItem(
         "dnd-characters",

--- a/dnd-frontend/src/pages/FineTuningDemo.tsx
+++ b/dnd-frontend/src/pages/FineTuningDemo.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Button } from "../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { Input } from "../components/ui/input";
+import { AIPersonalitySelector } from "../components/aicomponent/AIPersonalitySelector";
+import { PromptEditor } from "../components/aicomponent/PromptEditor";
+import { useNavigate } from "react-router-dom";
+import { Brain, Save, ArrowLeft } from "lucide-react";
+
+export function FineTuningDemo() {
+  const navigate = useNavigate();
+  const [personality, setPersonality] = useState("classic");
+  const [prompt, setPrompt] = useState("You are a helpful dungeon master.");
+  const [keywords, setKeywords] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = () => {
+    setSaving(true);
+    setTimeout(() => {
+      setSaving(false);
+      navigate(-1);
+    }, 800);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" onClick={() => navigate(-1)} className="text-gray-300 hover:text-white">
+            <ArrowLeft className="w-4 h-4 mr-2" /> Back
+          </Button>
+          <h1 className="text-3xl font-bold text-white flex items-center gap-2">
+            <Brain className="w-6 h-6" /> Fine-Tune AI DM
+          </h1>
+        </div>
+
+        <Card className="bg-black/20 border-purple-500/20">
+          <CardHeader>
+            <CardTitle className="text-white">Personality & Prompt</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <AIPersonalitySelector value={personality} onChange={setPersonality} />
+            <PromptEditor value={prompt} onChange={setPrompt} />
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Keywords</label>
+              <Input
+                value={keywords}
+                onChange={(e) => setKeywords(e.target.value)}
+                placeholder="dark, mysterious, undead..."
+                className="bg-card border border-border text-primary"
+              />
+            </div>
+            <Button onClick={handleSave} disabled={saving} className="mt-4 bg-primary hover:bg-primary/80">
+              <Save className="w-4 h-4 mr-2" /> {saving ? "Saving..." : "Save"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/dnd-frontend/src/pages/GameLobby.tsx
+++ b/dnd-frontend/src/pages/GameLobby.tsx
@@ -327,54 +327,19 @@ export function GameLobby() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="space-y-3">
-                  {room?.players.map((player) => (
-                    <div
-                      key={player.id}
-                      className="flex items-center justify-between p-3 rounded-lg bg-white/5"
-                    >
-                      <div>
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium text-white">
-                            {player.name}
-                          </span>
-                          {player.id === room.host && (
-                            <Badge variant="outline" className="text-xs">
-                              Host
-                            </Badge>
-                          )}
-                        </div>
-                        {player.character && (
-                          <div className="text-sm text-gray-400">
-                            {player.character.name} • Level{" "}
-                            {player.character.level} {player.character.class}
-                          </div>
-                        )}
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {player.character?.ready ? (
-                          <Badge className="bg-green-900/30 text-green-300">
-                            Ready
-                          </Badge>
-                        ) : (
-                          <Badge
-                            variant="secondary"
-                            className="bg-yellow-900/30 text-yellow-300"
-                          >
-                            Setup
-                          </Badge>
-                        )}
-                      </div>
-                    </div>
-                  ))}
+                <PlayerList
+                  players={(room?.players || []).map((p) => ({
+                    ...p,
+                    isHost: p.id === room?.host,
+                  }))}
+                />
 
-                  {!room?.players.length && (
-                    <div className="text-center text-gray-400 py-8">
-                      <Users className="w-12 h-12 mx-auto mb-2 opacity-50" />
-                      <p>Waiting for players to join...</p>
-                    </div>
-                  )}
-                </div>
+                {!room?.players.length && (
+                  <div className="text-center text-gray-400 py-8">
+                    <Users className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                    <p>Waiting for players to join...</p>
+                  </div>
+                )}
 
                 {/* AI DM Status */}
                 <div className="mt-6 pt-4 border-t border-gray-600">

--- a/dnd-frontend/src/pages/GameRoom.tsx
+++ b/dnd-frontend/src/pages/GameRoom.tsx
@@ -22,6 +22,7 @@ import { CharacterPanel } from "../components/character/CharacterPanel";
 import { DiceRoller } from "../components/game/DiceRoller";
 import { GameMap } from "../components/game/GameMap";
 import { ChatMessage } from "../components/chat/ChatMessage";
+import { CombatTracker } from "../components/game/CombatTracker";
 
 interface GameMessage {
   id: string;
@@ -358,25 +359,7 @@ export function GameRoom() {
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <div className="space-y-2">
-                      {gameState.turn?.initiative.map((participant) => (
-                        <div
-                          key={participant.id}
-                          className={`flex items-center justify-between p-2 rounded ${
-                            participant.id === gameState.turn?.currentPlayer
-                              ? "bg-red-500/20 border border-red-500/50"
-                              : "bg-white/5"
-                          }`}
-                        >
-                          <span className="text-white text-sm font-medium">
-                            {participant.name}
-                          </span>
-                          <Badge variant="outline" className="text-xs">
-                            {participant.initiative}
-                          </Badge>
-                        </div>
-                      ))}
-                    </div>
+                    <CombatTracker turn={gameState.turn} />
                   </CardContent>
                 </Card>
               )}

--- a/dnd-frontend/src/services/api-mock.ts
+++ b/dnd-frontend/src/services/api-mock.ts
@@ -1,5 +1,5 @@
 // Mock API service for testing navigation without backend
-const MOCK_ROOMS = new Map<string, any>();
+const MOCK_ROOMS = new Map<string, Record<string, unknown>>();
 
 // Generate a random room code
 function generateRoomCode(): string {


### PR DESCRIPTION
## Summary
- implement AIPersonalitySelector, PromptEditor, CombatTracker, PlayerList
- add FineTuningDemo page and route
- integrate CombatTracker and PlayerList into existing pages
- update component checklist and fix lint errors

## Testing
- `pnpm install`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68409927d5708323b161fda364d99512