### PR TITLE
Improve fine-tuning demo with mock API

### DIFF
--- a/dnd-frontend/src/pages/FineTuningDemo.tsx
+++ b/dnd-frontend/src/pages/FineTuningDemo.tsx
@@ -1,25 +1,99 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Brain, Save, ArrowLeft, Send } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card";
 import { Button } from "../components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Input } from "../components/ui/input";
+import { Textarea } from "../components/ui/textarea";
+import { ScrollArea } from "../components/ui/scroll-area";
 import { AIPersonalitySelector } from "../components/aicomponent/AIPersonalitySelector";
 import { PromptEditor } from "../components/aicomponent/PromptEditor";
-import { useNavigate } from "react-router-dom";
-import { Brain, Save, ArrowLeft } from "lucide-react";
+import { AIModelSelector } from "../components/aicomponent/AIModelSelector";
+import { ChatMessage } from "../components/chat/ChatMessage";
+import {
+  createFineTunedDM,
+  testFineTunedDM,
+  type FineTuningRequest,
+} from "../services/api-mock";
+
+interface SimpleMessage {
+  id: string;
+  type: "player" | "dm";
+  sender: string;
+  content: string;
+  timestamp: Date;
+}
 
 export function FineTuningDemo() {
   const navigate = useNavigate();
+
   const [personality, setPersonality] = useState("classic");
   const [prompt, setPrompt] = useState("You are a helpful dungeon master.");
   const [keywords, setKeywords] = useState("");
-  const [saving, setSaving] = useState(false);
+  const [model, setModel] = useState("gpt-4");
+  const [temperature, setTemperature] = useState(0.7);
+  const [maxTokens, setMaxTokens] = useState(300);
+  const [trainingData, setTrainingData] = useState("");
 
-  const handleSave = () => {
+  const [saving, setSaving] = useState(false);
+  const [currentMessage, setCurrentMessage] = useState("");
+  const [messages, setMessages] = useState<SimpleMessage[]>([]);
+
+  const buildRequest = (): FineTuningRequest => ({
+    campaignStyle: personality,
+    worldDescription: prompt,
+    keyNPCs: [],
+    campaignThemes: keywords
+      .split(",")
+      .map((k) => k.trim())
+      .filter(Boolean),
+    customPrompts: trainingData
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean),
+    model,
+    temperature,
+    maxTokens,
+    trainingData,
+  });
+
+  const handleSave = async () => {
     setSaving(true);
-    setTimeout(() => {
-      setSaving(false);
+    try {
+      await createFineTunedDM(buildRequest());
       navigate(-1);
-    }, 800);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSendTest = async () => {
+    if (!currentMessage.trim()) return;
+    const userMsg: SimpleMessage = {
+      id: Date.now().toString(),
+      type: "player",
+      sender: "You",
+      content: currentMessage,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setCurrentMessage("");
+    const res = await testFineTunedDM(buildRequest(), userMsg.content);
+    const aiMsg: SimpleMessage = {
+      id: Date.now().toString() + "_ai",
+      type: "dm",
+      sender: "AI DM",
+      content: res.response,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, aiMsg]);
   };
 
   return (
@@ -33,6 +107,40 @@ export function FineTuningDemo() {
             <Brain className="w-6 h-6" /> Fine-Tune AI DM
           </h1>
         </div>
+
+        <Card className="bg-black/20 border-purple-500/20">
+          <CardHeader>
+            <CardTitle className="text-white">Base Model & Settings</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <AIModelSelector value={model} onValueChange={setModel} />
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-muted-foreground">Temperature</label>
+              <Input
+                type="range"
+                min="0"
+                max="2"
+                step="0.1"
+                value={temperature}
+                onChange={(e) => setTemperature(parseFloat(e.target.value))}
+                className="w-full"
+              />
+              <p className="text-xs text-gray-400">Lower values =&gt; consistent. Higher =&gt; creative.</p>
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-muted-foreground">Max Tokens</label>
+              <Input
+                type="number"
+                min="50"
+                max="2000"
+                value={maxTokens}
+                onChange={(e) => setMaxTokens(parseInt(e.target.value))}
+                className="w-24 bg-card border border-border text-primary"
+              />
+              <p className="text-xs text-gray-400">Controls response length.</p>
+            </div>
+          </CardContent>
+        </Card>
 
         <Card className="bg-black/20 border-purple-500/20">
           <CardHeader>
@@ -50,9 +158,48 @@ export function FineTuningDemo() {
                 className="bg-card border border-border text-primary"
               />
             </div>
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Training Examples</label>
+              <Textarea
+                value={trainingData}
+                onChange={(e) => setTrainingData(e.target.value)}
+                placeholder="Example conversations or descriptions"
+                className="min-h-[100px] bg-card border border-border text-primary"
+              />
+              <p className="text-xs text-gray-400">
+                Provide short samples that capture your world&apos;s tone.
+              </p>
+            </div>
             <Button onClick={handleSave} disabled={saving} className="mt-4 bg-primary hover:bg-primary/80">
               <Save className="w-4 h-4 mr-2" /> {saving ? "Saving..." : "Save"}
             </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-black/20 border-purple-500/20">
+          <CardHeader>
+            <CardTitle className="text-white">Preview Chat</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <ScrollArea className="h-64 border border-border rounded-md p-2 bg-black/30">
+              <div className="space-y-4">
+                {messages.map((m) => (
+                  <ChatMessage key={m.id} message={m} />
+                ))}
+              </div>
+            </ScrollArea>
+            <div className="flex gap-2">
+              <Input
+                value={currentMessage}
+                onChange={(e) => setCurrentMessage(e.target.value)}
+                placeholder="Ask your DM..."
+                className="flex-1 bg-card border border-border"
+              />
+              <Button onClick={handleSendTest} disabled={!currentMessage.trim()} className="bg-primary hover:bg-primary/80">
+                <Send className="w-4 h-4" />
+              </Button>
+            </div>
+            <p className="text-xs text-gray-400">Send a message to see how the AI responds with current settings.</p>
           </CardContent>
         </Card>
       </div>

--- a/dnd-frontend/src/pages/GameLobby.tsx
+++ b/dnd-frontend/src/pages/GameLobby.tsx
@@ -27,6 +27,7 @@ import { Users, Settings, Play, Copy, CheckCircle, Brain } from "lucide-react";
 import { useSocket } from "../hooks/useSocket";
 import { CharacterSheet } from "../components/character/CharacterSheet";
 import { AIModelSelector } from "../components/aicomponent/AIModelSelector";
+import { PlayerList } from "../components/game/PlayerList";
 
 interface Player {
   id: string;

--- a/dnd-frontend/src/services/api-mock.ts
+++ b/dnd-frontend/src/services/api-mock.ts
@@ -64,3 +64,50 @@ const testRoom = {
 MOCK_ROOMS.set("TEST01", testRoom);
 
 console.log("Mock API initialized. Test room code: TEST01");
+
+// --- Fine-tuning mock ---
+export interface FineTuningRequest {
+  campaignStyle: string;
+  worldDescription: string;
+  keyNPCs: Array<{
+    name: string;
+    description: string;
+    personality: string;
+  }>;
+  campaignThemes: string[];
+  customPrompts: string[];
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  trainingData?: string;
+}
+
+const MOCK_FINE_TUNES = new Map<string, {
+  id: string;
+  name: string;
+  description: string;
+  config: FineTuningRequest;
+}>();
+
+export async function createFineTunedDM(request: FineTuningRequest) {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const id = `ft_${Math.random().toString(36).substring(2, 8)}`;
+  const model = {
+    id,
+    name: request.campaignStyle || "Custom DM",
+    description: request.worldDescription.slice(0, 60),
+    config: request,
+  };
+  MOCK_FINE_TUNES.set(id, model);
+  return { id: model.id, name: model.name, description: model.description };
+}
+
+export async function testFineTunedDM(
+  request: FineTuningRequest,
+  message: string
+) {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return {
+    response: `(${request.campaignStyle}) AI DM: ${message}`,
+  };
+}

--- a/dnd-frontend/src/services/api.ts
+++ b/dnd-frontend/src/services/api.ts
@@ -173,6 +173,10 @@ export interface FineTuningRequest {
   }>;
   campaignThemes: string[];
   customPrompts: string[];
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  trainingData?: string;
 }
 
 export async function createFineTunedDM(
@@ -181,6 +185,16 @@ export async function createFineTunedDM(
   return apiRequest("/ai/fine-tune", {
     method: "POST",
     body: JSON.stringify(request),
+  });
+}
+
+export async function testFineTunedDM(
+  request: FineTuningRequest,
+  message: string
+): Promise<{ response: string }> {
+  return apiRequest("/ai/fine-tune/test", {
+    method: "POST",
+    body: JSON.stringify({ config: request, message }),
   });
 }
 


### PR DESCRIPTION
## Summary
- extend fine-tuning API types and add mock functions
- import PlayerList in game lobby
- implement preview chat and advanced controls on fine-tuning demo page

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6840c8a1ce4c8323b43339568cbd6502