### PR TITLE
Add campaign list and lobby updates

### DIFF
--- a/dnd-frontend/src/App.tsx
+++ b/dnd-frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { LandingPage } from "./pages/LandingPage";
 import { GameLobby } from "./pages/GameLobby";
 import { GameRoom } from "./pages/GameRoom";
 import { CharacterLibrary } from "./pages/CharacterLibrary";
+import { Campaigns } from "./pages/Campaigns";
 import { CharacterCreate } from "./pages/CharacterCreate";
 import { CharacterEdit } from "./pages/CharacterEdit";
 import { CharacterView } from "./pages/CharacterView";
@@ -36,6 +37,7 @@ function App() {
             <Route path="/" element={<LandingPage />} />
             <Route path="/lobby/:roomCode?" element={<GameLobby />} />
             <Route path="/game/:roomCode" element={<GameRoom />} />
+            <Route path="/campaigns" element={<Campaigns />} />
             <Route path="/characters" element={<CharacterLibrary />} />
             <Route path="/characters/create" element={<CharacterCreate />} />
             <Route

--- a/dnd-frontend/src/lib/campaignStorage.ts
+++ b/dnd-frontend/src/lib/campaignStorage.ts
@@ -1,0 +1,21 @@
+export interface CampaignRecord {
+  code: string;
+  name: string;
+  joinedAt: string;
+}
+
+export function loadCampaigns(): CampaignRecord[] {
+  try {
+    return JSON.parse(localStorage.getItem("dnd-campaigns") || "[]");
+  } catch {
+    return [];
+  }
+}
+
+export function saveCampaign(campaign: { code: string; name: string }) {
+  const campaigns = loadCampaigns();
+  if (!campaigns.some((c) => c.code === campaign.code)) {
+    campaigns.push({ ...campaign, joinedAt: new Date().toISOString() });
+    localStorage.setItem("dnd-campaigns", JSON.stringify(campaigns));
+  }
+}

--- a/dnd-frontend/src/pages/Campaigns.tsx
+++ b/dnd-frontend/src/pages/Campaigns.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { loadCampaigns, CampaignRecord } from "../lib/campaignStorage";
+import { getRoomInfo } from "../services/api-mock";
+
+interface CampaignInfo extends CampaignRecord {
+  players?: number;
+  aiModel?: string;
+}
+
+export function Campaigns() {
+  const navigate = useNavigate();
+  const [campaigns, setCampaigns] = useState<CampaignInfo[]>([]);
+
+  useEffect(() => {
+    const stored = loadCampaigns();
+    Promise.all(
+      stored.map(async (c) => {
+        try {
+          const info = await getRoomInfo(c.code);
+          return { ...c, players: info.players.length, aiModel: info.aiModel };
+        } catch {
+          return c;
+        }
+      })
+    ).then(setCampaigns);
+  }, []);
+
+  return (
+    <div className="min-h-screen p-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold text-white">My Campaigns</h1>
+        {!campaigns.length ? (
+          <p className="text-gray-400">No campaigns joined yet.</p>
+        ) : (
+          <div className="space-y-4">
+            {campaigns.map((c) => (
+              <Card
+                key={c.code}
+                className="bg-white/10 backdrop-blur border-purple-500/20"
+              >
+                <CardHeader>
+                  <CardTitle className="text-white flex items-center justify-between">
+                    <span>{c.name}</span>
+                    <code className="text-purple-300 font-mono">{c.code}</code>
+                  </CardTitle>
+                  <CardDescription className="text-gray-300">
+                    Joined {new Date(c.joinedAt).toLocaleDateString()}
+                    {c.players != null && (
+                      <> • {c.players} players • {c.aiModel}</>
+                    )}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex gap-2">
+                  <Button
+                    onClick={() => navigate(`/lobby/${c.code}`)}
+                    className="bg-purple-600 hover:bg-purple-700"
+                  >
+                    Open Lobby
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dnd-frontend/src/pages/GameLobby.tsx
+++ b/dnd-frontend/src/pages/GameLobby.tsx
@@ -23,11 +23,12 @@ import {
   SelectValue,
 } from "../components/ui/select";
 import { Badge } from "../components/ui/badge";
-import { Users, Settings, Play, Copy, CheckCircle, Brain } from "lucide-react";
+import { Users, Settings, Play, Copy, CheckCircle, Brain, Info } from "lucide-react";
 import { useSocket } from "../hooks/useSocket";
 import { CharacterSheet } from "../components/character/CharacterSheet";
 import { AIModelSelector } from "../components/aicomponent/AIModelSelector";
 import { PlayerList } from "../components/game/PlayerList";
+import { saveCampaign } from "../lib/campaignStorage";
 
 interface Player {
   id: string;
@@ -111,6 +112,12 @@ export function GameLobby() {
   const allPlayersReady =
     room?.players.every((p) => p.character?.ready) && room.players.length > 0;
 
+  useEffect(() => {
+    if (joined && room) {
+      saveCampaign({ code: room.code, name: room.name });
+    }
+  }, [joined, room]);
+
   if (!joined) {
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
@@ -187,16 +194,25 @@ export function GameLobby() {
             </div>
           </div>
 
-          {isHost && (
+          <div className="flex gap-2 items-center">
             <Button
-              onClick={handleStartGame}
-              disabled={!allPlayersReady || !connected}
-              className="bg-green-600 hover:bg-green-700"
+              variant="outline"
+              onClick={() => navigate("/campaigns")}
+              className="border-gray-600 text-gray-300 hover:bg-gray-700"
             >
-              <Play className="w-4 h-4 mr-2" />
-              Start Adventure
+              Campaigns
             </Button>
-          )}
+            {isHost && (
+              <Button
+                onClick={handleStartGame}
+                disabled={!allPlayersReady || !connected}
+                className="bg-green-600 hover:bg-green-700"
+              >
+                <Play className="w-4 h-4 mr-2" />
+                Start Adventure
+              </Button>
+            )}
+          </div>
         </div>
 
         <div className="grid lg:grid-cols-3 gap-6">
@@ -356,6 +372,19 @@ export function GameLobby() {
                     </Badge>
                   </div>
                 </div>
+              </CardContent>
+            </Card>
+            <Card className="bg-white/10 backdrop-blur border-purple-500/20 mt-6">
+              <CardHeader>
+                <CardTitle className="text-white flex items-center">
+                  <Info className="w-5 h-5 mr-2" />
+                  Campaign Details
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-gray-300 space-y-1">
+                <div>AI Model: <span className="text-white">{room?.aiModel}</span></div>
+                <div>Host ID: <span className="text-white">{room?.host}</span></div>
+                <div>Players: <span className="text-white">{room?.players.length}</span></div>
               </CardContent>
             </Card>
           </div>

--- a/dnd-frontend/src/pages/LandingPage.tsx
+++ b/dnd-frontend/src/pages/LandingPage.tsx
@@ -19,6 +19,7 @@ import { Brain, Sparkles, Github, User, Users } from "lucide-react";
 // import { createRoom, joinRoom } from "../services/api";
 import { createRoom, joinRoom } from "../services/api-mock";
 import ctanDndMain from "/ctan-dnd-main.png?url";
+import { saveCampaign } from "../lib/campaignStorage";
 
 export function LandingPage() {
   const navigate = useNavigate();
@@ -32,6 +33,7 @@ export function LandingPage() {
     setLoading(true);
     try {
       const room = await createRoom(roomName);
+      saveCampaign({ code: room.code, name: room.name });
       navigate(`/lobby/${room.code}`);
     } catch (error) {
       console.error("Failed to create room:", error);
@@ -45,7 +47,8 @@ export function LandingPage() {
 
     setLoading(true);
     try {
-      await joinRoom(joinCode);
+      const room = await joinRoom(joinCode);
+      saveCampaign({ code: joinCode, name: room.name });
       navigate(`/lobby/${joinCode}`);
     } catch (error) {
       console.error("Failed to join room:", error);


### PR DESCRIPTION
## Summary
- manage created/joined campaigns in localStorage
- add Campaigns page to list user's campaigns
- record new campaigns on room creation/join
- extend GameLobby with campaign details and navigation
- route to Campaigns page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840cacf1f208323871a9dab3b254108