### PR TITLE
Add stub for async turn notifications

### DIFF
--- a/dnd-frontend/src/hooks/useTurnNotifications.ts
+++ b/dnd-frontend/src/hooks/useTurnNotifications.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { Socket } from "socket.io-client";
+
+interface TurnNotification {
+  playerId: string;
+  summary: string;
+}
+
+export function useTurnNotifications(
+  playerId: string | null,
+  socket: Socket | null
+) {
+  useEffect(() => {
+    if (!socket || !playerId) return;
+
+    if (typeof window !== "undefined" && "Notification" in window) {
+      if (Notification.permission === "default") {
+        Notification.requestPermission();
+      }
+    }
+
+    const handler = (payload: TurnNotification) => {
+      if (
+        payload.playerId === playerId &&
+        typeof window !== "undefined" &&
+        "Notification" in window &&
+        Notification.permission === "granted"
+      ) {
+        new Notification("Your turn", { body: payload.summary });
+      }
+    };
+
+    socket.on("turn-notification", handler);
+    return () => {
+      socket.off("turn-notification", handler);
+    };
+  }, [socket, playerId]);
+}

--- a/dnd-frontend/src/pages/GameLobby.tsx
+++ b/dnd-frontend/src/pages/GameLobby.tsx
@@ -72,6 +72,14 @@ export function GameLobby() {
 
     const handlePlayerJoined = (player: Player) => {
       setCurrentPlayer(player);
+      try {
+        localStorage.setItem(
+          "dnd-current-player",
+          JSON.stringify(player)
+        );
+      } catch {
+        // ignore storage errors
+      }
       setJoined(true);
     };
 

--- a/dnd-frontend/src/pages/GameRoom.tsx
+++ b/dnd-frontend/src/pages/GameRoom.tsx
@@ -18,6 +18,7 @@ import { ScrollArea } from "../components/ui/scroll-area";
 import { Badge } from "../components/ui/badge";
 import { Send, Dice6, Users, Map, BookOpen, Brain, Sword } from "lucide-react";
 import { useSocket } from "../hooks/useSocket";
+import { useTurnNotifications } from "../hooks/useTurnNotifications";
 import { CharacterPanel } from "../components/character/CharacterPanel";
 import { DiceRoller } from "../components/game/DiceRoller";
 import { GameMap } from "../components/game/GameMap";
@@ -64,6 +65,15 @@ export function GameRoom() {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const { socket } = useSocket();
+  const player = (() => {
+    if (typeof window === "undefined") return null;
+    try {
+      return JSON.parse(localStorage.getItem("dnd-current-player") || "null");
+    } catch {
+      return null;
+    }
+  })();
+  useTurnNotifications(player?.id ?? null, socket);
 
   useEffect(() => {
     if (!socket || !roomCode) return;


### PR DESCRIPTION
## Summary
- track joining player in localStorage
- create `useTurnNotifications` hook
- notify player when `turn-notification` socket event fires

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840d427b29c83239de0138f66cc756f