### PR TITLE
Add community DM sharing

### DIFF
--- a/dnd-frontend/src/App.tsx
+++ b/dnd-frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { CharacterCreate } from "./pages/CharacterCreate";
 import { CharacterEdit } from "./pages/CharacterEdit";
 import { CharacterView } from "./pages/CharacterView";
 import { FineTuningDemo } from "./pages/FineTuningDemo";
+import { DMLibrary } from "./pages/DMLibrary";
 import { LoginPage } from "./pages/LoginPage";
 import { RegisterPage } from "./pages/RegisterPage";
 import "./App.css";
@@ -51,6 +52,7 @@ function App() {
               element={<CharacterView />}
             />
             <Route path="/fine-tune" element={<FineTuningDemo />} />
+            <Route path="/dm-library" element={<DMLibrary />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/dnd-frontend/src/components/ui/navbar.tsx
+++ b/dnd-frontend/src/components/ui/navbar.tsx
@@ -43,6 +43,9 @@ export function Navbar() {
           <Link to="/characters" className="hover:text-primary">
             Characters
           </Link>
+          <Link to="/dm-library" className="hover:text-primary">
+            DM Library
+          </Link>
           <Link to="/about" className="hover:text-primary">
             About
           </Link>

--- a/dnd-frontend/src/pages/Campaigns.tsx
+++ b/dnd-frontend/src/pages/Campaigns.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "../components/ui/card";
 import { Button } from "../components/ui/button";
-import { loadCampaigns, CampaignRecord } from "../lib/campaignStorage";
+import { loadCampaigns, type CampaignRecord } from "../lib/campaignStorage";
 import { getRoomInfo } from "../services/api-mock";
 
 interface CampaignInfo extends CampaignRecord {

--- a/dnd-frontend/src/pages/DMLibrary.tsx
+++ b/dnd-frontend/src/pages/DMLibrary.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "../components/ui/card";
+import { getPublicFineTunedDMs } from "../services/api-mock";
+
+interface PublicDM {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export function DMLibrary() {
+  const [dms, setDms] = useState<PublicDM[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getPublicFineTunedDMs()
+      .then(setDms)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="min-h-screen p-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold text-white">Community DM Library</h1>
+        {loading ? (
+          <p className="text-gray-400">Loading...</p>
+        ) : !dms.length ? (
+          <p className="text-gray-400">No shared DMs yet.</p>
+        ) : (
+          <div className="space-y-4">
+            {dms.map((dm) => (
+              <Card
+                key={dm.id}
+                className="bg-white/10 backdrop-blur border-purple-500/20"
+              >
+                <CardHeader>
+                  <CardTitle className="text-white">{dm.name}</CardTitle>
+                  <CardDescription className="text-gray-300">
+                    {dm.description}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <code className="text-purple-300 font-mono">{dm.id}</code>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dnd-frontend/src/pages/FineTuningDemo.tsx
+++ b/dnd-frontend/src/pages/FineTuningDemo.tsx
@@ -70,6 +70,7 @@ export function FineTuningDemo() {
   const [saving, setSaving] = useState(false);
   const [currentMessage, setCurrentMessage] = useState("");
   const [messages, setMessages] = useState<SimpleMessage[]>([]);
+  const [sharePublicly, setSharePublicly] = useState(false);
 
   const buildRequest = (): FineTuningRequest => ({
     campaignStyle: personality,
@@ -90,6 +91,7 @@ export function FineTuningDemo() {
     trainingSteps,
     learningRate,
     quantization,
+    sharePublicly,
   });
 
   const handleSave = async () => {
@@ -247,6 +249,18 @@ export function FineTuningDemo() {
                   <p className="text-xs text-gray-400">
                     Provide short samples that capture your world&apos;s tone.
                   </p>
+                </div>
+                <div className="flex items-center gap-2 mt-2">
+                  <input
+                    id="sharePublicly"
+                    type="checkbox"
+                    checked={sharePublicly}
+                    onChange={(e) => setSharePublicly(e.target.checked)}
+                    className="size-4 accent-purple-600"
+                  />
+                  <label htmlFor="sharePublicly" className="text-sm text-muted-foreground">
+                    Share publicly in DM library
+                  </label>
                 </div>
                 <Button onClick={handleSave} disabled={saving} className="mt-4 bg-primary hover:bg-primary/80">
                   <Save className="w-4 h-4 mr-2" /> {saving ? "Saving..." : "Save"}

--- a/dnd-frontend/src/services/api-mock.ts
+++ b/dnd-frontend/src/services/api-mock.ts
@@ -1,12 +1,25 @@
 // Mock API service for testing navigation without backend
-const MOCK_ROOMS = new Map<string, Record<string, unknown>>();
+interface MockRoom {
+  code: string;
+  name: string;
+  id: string;
+  host: string;
+  players: Array<Record<string, unknown>>;
+  aiModel: string;
+  status: string;
+}
+
+const MOCK_ROOMS = new Map<string, MockRoom>();
 
 // Generate a random room code
 function generateRoomCode(): string {
   return Math.random().toString(36).substring(2, 8).toUpperCase();
 }
 
-export async function createRoom(name: string, aiModel: string = "gpt-4") {
+export async function createRoom(
+  name: string,
+  aiModel: string = "gpt-4"
+): Promise<{ code: string; name: string; id: string }> {
   // Simulate API delay
   await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -30,7 +43,7 @@ export async function createRoom(name: string, aiModel: string = "gpt-4") {
   };
 }
 
-export async function joinRoom(code: string) {
+export async function joinRoom(code: string): Promise<MockRoom> {
   // Simulate API delay
   await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -42,7 +55,7 @@ export async function joinRoom(code: string) {
   return room;
 }
 
-export async function getRoomInfo(code: string) {
+export async function getRoomInfo(code: string): Promise<MockRoom> {
   const room = MOCK_ROOMS.get(code);
   if (!room) {
     throw new Error(`Room ${code} not found`);
@@ -83,6 +96,7 @@ export interface FineTuningRequest {
   trainingSteps?: number;
   learningRate?: number;
   quantization?: string;
+  sharePublicly?: boolean;
 }
 
 const MOCK_FINE_TUNES = new Map<string, {
@@ -90,6 +104,7 @@ const MOCK_FINE_TUNES = new Map<string, {
   name: string;
   description: string;
   config: FineTuningRequest;
+  public: boolean;
 }>();
 
 export async function createFineTunedDM(request: FineTuningRequest) {
@@ -100,6 +115,7 @@ export async function createFineTunedDM(request: FineTuningRequest) {
     name: request.campaignStyle || "Custom DM",
     description: request.worldDescription.slice(0, 60),
     config: request,
+    public: !!request.sharePublicly,
   };
   MOCK_FINE_TUNES.set(id, model);
   return { id: model.id, name: model.name, description: model.description };
@@ -113,4 +129,11 @@ export async function testFineTunedDM(
   return {
     response: `(${request.campaignStyle}) AI DM: ${message}`,
   };
+}
+
+export async function getPublicFineTunedDMs() {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return Array.from(MOCK_FINE_TUNES.values())
+    .filter((m) => m.public)
+    .map((m) => ({ id: m.id, name: m.name, description: m.description }));
 }

--- a/dnd-frontend/src/services/api.ts
+++ b/dnd-frontend/src/services/api.ts
@@ -180,6 +180,7 @@ export interface FineTuningRequest {
   trainingSteps?: number;
   learningRate?: number;
   quantization?: string;
+  sharePublicly?: boolean;
 }
 
 export async function createFineTunedDM(
@@ -199,6 +200,12 @@ export async function testFineTunedDM(
     method: "POST",
     body: JSON.stringify({ config: request, message }),
   });
+}
+
+export async function getPublicFineTunedDMs(): Promise<
+  Array<{ id: string; name: string; description: string }>
+> {
+  return apiRequest("/ai/fine-tune/public");
 }
 
 export async function getAvailableModels(): Promise<


### PR DESCRIPTION
## Summary
- add interface to share fine-tuned DMs publicly
- implement a new `DMLibrary` page that lists shared DMs
- support sharing via toggle in `FineTuningDemo`
- update mock API and real API bindings
- expose DM Library via navbar and routing

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684103300cc8832390a2f8d6a92135d8