### PR TITLE
Improve responsiveness of page containers

### DIFF
--- a/dnd-frontend/src/App.css
+++ b/dnd-frontend/src/App.css
@@ -1,8 +1,7 @@
 #root {
-  max-width: 1280px;
+  width: 100%;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 0;
 }
 
 .logo {

--- a/dnd-frontend/src/pages/Campaigns.tsx
+++ b/dnd-frontend/src/pages/Campaigns.tsx
@@ -30,7 +30,7 @@ export function Campaigns() {
 
   return (
     <div className="min-h-screen p-4">
-      <div className="max-w-3xl mx-auto space-y-6">
+      <div className="w-full mx-auto space-y-6">
         <h1 className="text-3xl font-bold text-white">My Campaigns</h1>
         {!campaigns.length ? (
           <p className="text-gray-400">No campaigns joined yet.</p>

--- a/dnd-frontend/src/pages/CharacterCreate.tsx
+++ b/dnd-frontend/src/pages/CharacterCreate.tsx
@@ -292,7 +292,7 @@ export function CharacterCreate() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-4">
-      <div className="max-w-4xl mx-auto">
+      <div className="w-full mx-auto">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-4">

--- a/dnd-frontend/src/pages/CharacterEdit.tsx
+++ b/dnd-frontend/src/pages/CharacterEdit.tsx
@@ -282,7 +282,7 @@ export function CharacterEdit() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-4">
-      <div className="max-w-4xl mx-auto">
+      <div className="w-full mx-auto">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-4">

--- a/dnd-frontend/src/pages/CharacterLibrary.tsx
+++ b/dnd-frontend/src/pages/CharacterLibrary.tsx
@@ -206,7 +206,7 @@ export function CharacterLibrary() {
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
       {/* Header */}
       <div className="border-b border-purple-500/20 bg-black/20 backdrop-blur">
-        <div className="max-w-7xl mx-auto px-4 py-6">
+        <div className="w-full mx-auto px-4 py-6">
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-3xl font-bold text-white flex items-center gap-3">
@@ -227,7 +227,7 @@ export function CharacterLibrary() {
       </div>
 
       {/* Filters */}
-      <div className="max-w-7xl mx-auto px-4 py-6">
+      <div className="w-full mx-auto px-4 py-6">
         <Card className="bg-white/10 backdrop-blur border-purple-500/20 mb-6">
           <CardContent className="p-4">
             <div className="flex flex-wrap gap-4 items-center">

--- a/dnd-frontend/src/pages/CharacterView.tsx
+++ b/dnd-frontend/src/pages/CharacterView.tsx
@@ -121,7 +121,7 @@ export function CharacterView() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-4">
-      <div className="max-w-4xl mx-auto">
+      <div className="w-full mx-auto">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-4">

--- a/dnd-frontend/src/pages/DMLibrary.tsx
+++ b/dnd-frontend/src/pages/DMLibrary.tsx
@@ -26,7 +26,7 @@ export function DMLibrary() {
 
   return (
     <div className="min-h-screen p-4">
-      <div className="max-w-3xl mx-auto space-y-6">
+      <div className="w-full mx-auto space-y-6">
         <h1 className="text-3xl font-bold text-white">Community DM Library</h1>
         {loading ? (
           <p className="text-gray-400">Loading...</p>

--- a/dnd-frontend/src/pages/FineTuningDemo.tsx
+++ b/dnd-frontend/src/pages/FineTuningDemo.tsx
@@ -172,7 +172,7 @@ export function FineTuningDemo() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-4">
-      <div className="max-w-3xl mx-auto space-y-6">
+      <div className="w-full mx-auto space-y-6">
         <div className="flex items-center justify-between">
           <Button variant="ghost" onClick={() => navigate(-1)} className="text-gray-300 hover:text-white">
             <ArrowLeft className="w-4 h-4 mr-2" /> Back

--- a/dnd-frontend/src/pages/GameLobby.tsx
+++ b/dnd-frontend/src/pages/GameLobby.tsx
@@ -129,7 +129,7 @@ export function GameLobby() {
   if (!joined) {
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
-        <Card className="w-full max-w-md bg-white/10 backdrop-blur border-purple-500/20">
+        <Card className="w-full bg-white/10 backdrop-blur border-purple-500/20">
           <CardHeader>
             <CardTitle className="text-2xl text-center text-white">
               Join Game
@@ -168,7 +168,7 @@ export function GameLobby() {
 
   return (
     <div className="min-h-screen p-4">
-      <div className="max-w-6xl mx-auto">
+      <div className="w-full mx-auto">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div>

--- a/dnd-frontend/src/pages/LandingPage.tsx
+++ b/dnd-frontend/src/pages/LandingPage.tsx
@@ -59,7 +59,7 @@ export function LandingPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4 bg-background text-foreground">
-      <div className="max-w-4xl mx-auto shadow-lg rounded-lg border border-border bg-card">
+      <div className="w-full mx-auto shadow-lg rounded-lg border border-border bg-card">
         {/* Hero Section */}
         <div className="text-center mb-12 mt-2">
           <div className="flex items-center justify-center mb-6">

--- a/dnd-frontend/src/pages/LoginPage.tsx
+++ b/dnd-frontend/src/pages/LoginPage.tsx
@@ -22,7 +22,7 @@ export function LoginPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4 bg-background text-foreground">
-      <Card className="w-full max-w-md border border-border bg-card shadow-lg">
+      <Card className="w-full border border-border bg-card shadow-lg">
         <CardHeader className="text-center">
           <img src="/ctan-dnd-main.png" alt="logo" className="w-12 h-12 mx-auto mb-2" />
           <CardTitle className="text-3xl text-primary">Welcome Back</CardTitle>

--- a/dnd-frontend/src/pages/RegisterPage.tsx
+++ b/dnd-frontend/src/pages/RegisterPage.tsx
@@ -28,7 +28,7 @@ export function RegisterPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4 bg-background text-foreground">
-      <Card className="w-full max-w-md border border-border bg-card shadow-lg">
+      <Card className="w-full border border-border bg-card shadow-lg">
         <CardHeader className="text-center">
           <img src="/ctan-dnd-main.png" alt="logo" className="w-12 h-12 mx-auto mb-2" />
           <CardTitle className="text-3xl text-primary">Create Account</CardTitle>


### PR DESCRIPTION
## Summary
- remove root element max-width restriction
- expand major page containers to full width
- widen login and register cards

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68411f37ea5083239d819cc1788455bb